### PR TITLE
feat: add safe api exposing results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod wasapi;
 pub mod pulseaudio;
 
 pub mod error;
+pub mod safe;
 
 #[cfg(feature = "debug")]
 fn debug_eprintln(message: &str){
@@ -88,34 +89,12 @@ enum DeviceType {
 
 /// Gathers the human readable device name of each output device detected
 pub fn get_sound_devices() -> Vec<String> {
-    let mut devices:Vec<String> = Vec::new();
-    #[cfg(target_os="macos")] {
-        devices = coreaudio::get_sound_devices().unwrap();
-    }
-    #[cfg(target_os="windows")] {
-        devices = wasapi::get_sound_devices().unwrap_or(Vec::new())
-    }
-    #[cfg(target_os="linux")] {
-        devices = pulseaudio::PulseAudio::get_sound_devices().unwrap_or(Vec::new())
-    }
-    devices
+    safe::get_sound_devices().unwrap_or(Vec::new())
 }
 
 /// Gathers the current volume in percent of the default output device
 pub fn get_system_volume() -> u8 {
-    #[allow(unused_assignments)]
-    let mut vol: u8 = 0;
-    #[cfg(target_os="macos")] {
-       vol = (coreaudio::get_vol().unwrap() * 100.0) as u8;
-    }
-    #[cfg(target_os="windows")] {
-        // println!("{}", wasapi::WASAPI::get_vol().unwrap());
-        vol = (wasapi::get_vol().unwrap() * 100.0) as u8;
-    }
-    #[cfg(target_os="linux")] {
-        vol = (pulseaudio::PulseAudio::get_vol().unwrap() * 100.0) as u8;
-    }
-    vol
+    safe::get_system_volume().unwrap()
 
 }
 
@@ -124,67 +103,23 @@ pub fn get_system_volume() -> u8 {
 /// ## On macOS
 /// `cpvc` needs to mute and unmute the audio device to get the hardware device volume to sync 
 pub fn set_system_volume(percent: u8) -> bool {
-    #[allow(unused_assignments)]
-    let mut success = None;
-    #[cfg(target_os="macos")] {
-        if let Ok(_) = coreaudio::set_vol(percent as f32 / 100.0) {
-            success = Some(true)
-        } else {
-            success.replace(false);
-        }
+    if let Ok(_) = safe::set_system_volume(percent) {
+        true
+    } else {
+        false
     }
-    #[cfg(target_os="windows")] {
-       if let Ok(_) = wasapi::set_vol(percent as f32 / 100.0) {
-            success = Some(true)
-       }
-    }
-    #[cfg(target_os="linux")] {
-        if let Ok(_) = pulseaudio::PulseAudio::set_vol(percent as f32 / 100.0) {
-            success = Some(true)
-       }
-    }
-
-    success.unwrap_or(false)
 }
 
 pub fn set_mute(mute: bool) -> bool {
-    let mut status = false;
-    #[cfg(target_os="macos")] {
-        if let Ok(_) = coreaudio::set_mute(mute) {
-            status = true
-        } else {
-            status = false;
-        }
+    if let Ok(_) = safe::set_mute(mute) {
+        true
+    } else {
+        false
     }
-    #[cfg(target_os="windows")]
-    {
-       if let Ok(_) = wasapi::set_mute(mute) {
-            status = true
-        } else {
-            status = false;
-        }
-    }
-    #[cfg(target_os="linux")] {
-        if let Ok(_) = pulseaudio::PulseAudio::set_mute(mute) {
-            status = true
-        } else {
-            status = false;
-        }
-    }
-    status
 }
 
 pub fn get_mute() -> bool {
-    #[cfg(target_os="macos")] {
-        return coreaudio::get_mute().unwrap_or(false);
-    }
-    #[cfg(target_os="windows")] {
-        return wasapi::get_mute().unwrap_or(false);
-    }
-    #[cfg(target_os="linux")] {
-        return pulseaudio::PulseAudio::get_mute().unwrap_or(false);
-    }
-    false
+    safe::get_mute().unwrap_or(false)
 }
 
 // TODO add get_default_output_device() function back

--- a/src/safe.rs
+++ b/src/safe.rs
@@ -1,0 +1,126 @@
+#[cfg(target_os = "macos")]
+use crate::coreaudio;
+#[cfg(target_os = "linux")]
+use crate::pulseaudio;
+#[cfg(target_os = "windows")]
+use crate::wasapi;
+
+pub type Result<T> = std::result::Result<T, super::error::Error>;
+
+/// Gathers the human readable device name of each output device detected
+pub fn get_sound_devices() -> Result<Vec<String>> {
+    #[cfg(target_os = "macos")]
+    {
+        return coreaudio::get_sound_devices();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return wasapi::get_sound_devices();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return pulseaudio::PulseAudio::get_sound_devices();
+    }
+}
+
+/// Gathers the current volume in percent of the default output device
+pub fn get_system_volume() -> Result<u8> {
+    #[cfg(target_os = "macos")]
+    {
+        return Ok((coreaudio::get_vol()? * 100.0) as u8);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // println!("{}", wasapi::WASAPI::get_vol()?);
+        return Ok((wasapi::get_vol()? * 100.0) as u8);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return Ok((pulseaudio::PulseAudio::get_vol()? * 100.0) as u8);
+    }
+}
+
+/// Sets the current volume in percent of the default output device
+/// ## On macOS
+/// `cpvc` needs to mute and unmute the audio device to get the hardware device volume to sync
+pub fn set_system_volume(percent: u8) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return coreaudio::set_vol(percent as f32 / 100.0);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return wasapi::set_vol(percent as f32 / 100.0);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return pulseaudio::PulseAudio::set_vol(percent as f32 / 100.0);
+    }
+}
+
+pub fn set_mute(mute: bool) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return coreaudio::set_mute(mute);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return wasapi::set_mute(mute);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return pulseaudio::PulseAudio::set_mute(mute);
+    }
+}
+
+pub fn get_mute() -> Result<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        return coreaudio::get_mute();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return wasapi::get_mute();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return pulseaudio::PulseAudio::get_mute();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sound_devices() -> Result<()> {
+        dbg!(get_sound_devices()?);
+        Ok(())
+    }
+
+    #[test]
+    fn set_sound_test() -> Result<()> {
+        dbg!(set_system_volume(2)?);
+        Ok(())
+    }
+
+    #[test]
+    fn get_sound_test() -> Result<()> {
+        dbg!(get_system_volume()?);
+        Ok(())
+    }
+
+    #[test]
+    fn set_mute_test() -> Result<()> {
+        dbg!(set_mute(true)?);
+        dbg!(get_system_volume()?);
+        Ok(())
+    }
+
+    #[test]
+    fn get_mute_status() -> Result<()> {
+        dbg!(get_mute()?);
+        dbg!(get_system_volume()?);
+        Ok(())
+    }
+}

--- a/src/safe.rs
+++ b/src/safe.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use crate::VolumeControl;
 #[cfg(target_os = "macos")]
 use crate::coreaudio;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Hello,

Thank you for your work on this crate.
I'm working on a `node.js` library that expose native bindings to this crate: [@touchifyapp/cpvc](https://github.com/touchifyapp/node-cpvc)

During my tests, I noticed that on crate level functions, you unwrap the result which force the package to panic.
However, for my package, I want to expose the error instead on panicking.

So, to avoid breaking changes, I created a `safe` module that exposes the same functions but returning the `Result`.
I also copied tests on that module.

The crate-level functions keep their signature and behavior but use the `safe` wrapper to simplify the code.