### PR TITLE
feat: create unified device API 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /ignore*
+*.old

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Basic cross platform crate for interacting with Audio Devices and handling Syste
 
 * Windows:
     * Windows 11 24H2
+    * Windows 11 LTSC 24H2
 
 * Linux:
    * EndeavourOS Mercury
+   * Debian Trixie
 
 ## Development Details
 
@@ -37,6 +39,12 @@ Basic cross platform crate for interacting with Audio Devices and handling Syste
 * Linux: 
     * `libpulse-binding`
     * `libpulse-sys`
+
+# Dependencies 
+* Linux:
+    * Alsa dev package
+        * Debian: `libasound2-dev`
+        * Arch: `alsa-lib`
 
 
 ### Why only PulseAudio?

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -71,15 +71,22 @@ pub mod coreaudio {
             }
             for device in &device_details {
                 if *device != 0 {
-                    let name = get_device_name(*device).unwrap();
-                    match check_device_type(*device) {
-                        DeviceType::Input => {
-                            // May Add Future Functionality
-                        },
-                        DeviceType::Output => {
-                            devices.push((*device, name));
-                        },
-                        DeviceType::None => {}
+                    if let Ok(name) = get_device_name(*device) {
+                        match check_device_type(*device) {
+                            DeviceType::Input => {
+                                // May Add Future Functionality
+                            },
+                            DeviceType::Output => {
+                                devices.push((*device, name));
+                            },
+                            DeviceType::None => {}
+                        }
+                    } else {
+                        // ! Silent Failures may occur if there is an error when the name certain device ids are requested
+                        // ! From testing, these errors are usually safe to ignore
+                        
+                        debug_eprintln(&format!("Silent Name Capture Failure on device with id: {}", *device));
+                        // println!("Silent Name Capture Failure on device with id: {}", *device);
                     }
                 }
             }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,5 +1,20 @@
 use crate::error::{self, Error};
 
+#[cfg(target_os = "linux")]
+use crate::pulseaudio::device::PulseAudioDevice;
+#[cfg(target_os = "linux")]
+pub type Device = UnifiedDevice<PulseAudioDevice>;
+
+#[cfg(target_os = "windows")]
+use crate::wasapi::device::WASAPIDevice;
+#[cfg(target_os = "windows")]
+pub type Device = UnifiedDevice<WASAPIDevice>;
+
+#[cfg(target_os = "macos")]
+use crate::coreaudio::device::CoreAudioDevice;
+#[cfg(target_os = "macos")]
+pub type Device = UnifiedDevice<CoreAudioDevice>;
+
 pub trait DeviceTrait {
     fn from_name(name: String) -> Result<Self, Error> where Self: Sized {
         Err(Error::PlatformUnsupported)
@@ -31,22 +46,22 @@ pub trait DeviceTrait {
 
 }
 
-struct Device<T: DeviceTrait> {
+pub struct UnifiedDevice<T: DeviceTrait> {
     device: T,
 }
 
-impl<T> Device<T> 
+impl<T> UnifiedDevice<T> 
 where 
     T: DeviceTrait
 {
     pub fn from_device(device: T) -> Self {
-        Device {
+        UnifiedDevice {
             device
         }
     }
 
     pub fn from_uid(uid: String) -> Result<Self, Error> {
-        Ok(Device {
+        Ok(UnifiedDevice {
             device: {
                 match T::from_uid(uid) {
                     Ok(device) => {
@@ -61,7 +76,7 @@ where
     }
 
     pub fn from_name(name: String) -> Result<Self, Error> {
-        Ok(Device {
+        Ok(UnifiedDevice {
             device: {
                 match T::from_name(name) {
                     Ok(device) => {
@@ -99,7 +114,7 @@ mod test {
 
     #[test]
     fn test_unified_device() {
-        let device = Device::<CoreAudioDevice>::from_name("".to_string()).unwrap();
+        let device = Device::from_name("".to_string()).unwrap();
         dbg!(device.get_mute());
         assert!(false);
     }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -110,7 +110,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{coreaudio::device::CoreAudioDevice, device::Device};
+
+    use super::*;
 
     #[test]
     fn test_unified_device() {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -31,6 +31,17 @@ pub trait DeviceTrait {
 
 }
 
-struct Device {
+struct Device<T: DeviceTrait> {
+    device: T,
+}
 
+impl<T> Device<T> 
+where 
+    T: DeviceTrait
+{
+    pub fn new(device: T) -> Self {
+        Device {
+            device
+        }
+    }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{self, Error};
 
 pub trait DeviceTrait {
     fn from_name(name: String) -> Result<Self, Error> where Self: Sized {
@@ -39,9 +39,68 @@ impl<T> Device<T>
 where 
     T: DeviceTrait
 {
-    pub fn new(device: T) -> Self {
+    pub fn from_device(device: T) -> Self {
         Device {
             device
         }
+    }
+
+    pub fn from_uid(uid: String) -> Result<Self, Error> {
+        Ok(Device {
+            device: {
+                match T::from_uid(uid) {
+                    Ok(device) => {
+                        device
+                    }
+                    Err(error ) => {
+                        return Err(error)
+                    }
+                }
+            }
+        })
+    }
+
+    pub fn from_name(name: String) -> Result<Self, Error> {
+        Ok(Device {
+            device: {
+                match T::from_name(name) {
+                    Ok(device) => {
+                        device
+                    }
+                    Err(error ) => {
+                        return Err(error)
+                    }
+                }
+            }
+        })
+    }
+
+    pub fn get_vol(&self) -> Result<f32, Error> {
+        self.device.get_vol()
+    }
+
+    pub fn set_vol(&self, vol: f32) -> Result<(), Error> {
+        self.device.set_vol(vol)
+    }
+
+    pub fn get_mute(&self) -> Result<bool, Error> {
+        self.device.get_mute()
+    }
+
+    pub fn set_mute(&self, mute: bool) -> Result<(), Error> {
+        self.device.set_mute(mute)
+    }
+
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{coreaudio::device::CoreAudioDevice, device::Device};
+
+    #[test]
+    fn test_unified_device() {
+        let device = Device::<CoreAudioDevice>::from_name("".to_string()).unwrap();
+        dbg!(device.get_mute());
+        assert!(false);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ pub mod device;
 
 pub mod coreaudio;
 pub mod wasapi;
-#[cfg(target_os = "linux")]
 pub mod pulseaudio;
 
 pub mod error;
@@ -96,7 +95,7 @@ pub fn get_sound_devices() -> Vec<String> {
         devices = wasapi::get_sound_devices().unwrap_or(Vec::new())
     }
     #[cfg(target_os="linux")] {
-        devices = pulseaudio::PulseAudio::get_sound_devices().unwrap_or(Vec::new())
+        devices = pulseaudio::get_sound_devices().unwrap_or(Vec::new())
     }
     devices
 }
@@ -113,7 +112,7 @@ pub fn get_system_volume() -> u8 {
         vol = (wasapi::get_vol().unwrap() * 100.0) as u8;
     }
     #[cfg(target_os="linux")] {
-        vol = (pulseaudio::PulseAudio::get_vol().unwrap() * 100.0) as u8;
+        vol = (pulseaudio::get_vol().unwrap() * 100.0) as u8;
     }
     vol
 
@@ -139,7 +138,7 @@ pub fn set_system_volume(percent: u8) -> bool {
        }
     }
     #[cfg(target_os="linux")] {
-        if let Ok(_) = pulseaudio::PulseAudio::set_vol(percent as f32 / 100.0) {
+        if let Ok(_) = pulseaudio::set_vol(percent as f32 / 100.0) {
             success = Some(true)
        }
     }
@@ -165,7 +164,7 @@ pub fn set_mute(mute: bool) -> bool {
         }
     }
     #[cfg(target_os="linux")] {
-        if let Ok(_) = pulseaudio::PulseAudio::set_mute(mute) {
+        if let Ok(_) = pulseaudio::set_mute(mute) {
             status = true
         } else {
             status = false;
@@ -182,7 +181,7 @@ pub fn get_mute() -> bool {
         return wasapi::get_mute().unwrap_or(false);
     }
     #[cfg(target_os="linux")] {
-        return pulseaudio::PulseAudio::get_mute().unwrap_or(false);
+        return pulseaudio::get_mute().unwrap_or(false);
     }
     false
 }
@@ -228,7 +227,9 @@ mod tests {
         }
         
         #[cfg(target_os="linux")] {
-            let device = pulseaudio::device::PulseAudioDevice::from_id("".to_string()).unwrap();
+            use crate::device::DeviceTrait;
+
+            let device = pulseaudio::device::PulseAudioDevice::from_uid("".to_string()).unwrap();
             dbg!(device.get_device_str());
             dbg!(device.get_name());
             dbg!(device.set_mute(false));
@@ -251,7 +252,7 @@ mod tests {
             }
         }
         #[cfg(target_os="linux")] {
-            let devices = pulseaudio::PulseAudio::get_device_identifiers().unwrap();
+            let devices = pulseaudio::get_device_identifiers().unwrap();
             dbg!(&devices);
             for (device_id, name) in devices {
                 println!("{}", format!("DEVICE STR {}, NAME: {}", unsafe {device_id.to_string()}, name));

--- a/src/pulseaudio/device.rs
+++ b/src/pulseaudio/device.rs
@@ -1,310 +1,345 @@
+// #[cfg(not(target_os="linux"))]
+#[cfg(target_os="linux")]
 
-use std::sync::{Arc, Mutex};
-use crate::{debug_eprintln, debug_println, error::Error, pulseaudio::PulseAudio};
+mod device {
 
-pub struct PulseAudioDevice {
-    dev_str: String,
-}
+    use std::sync::{Arc, Mutex};
+    use crate::{debug_eprintln, debug_println, device::DeviceTrait, error::Error, pulseaudio};
 
-impl PulseAudioDevice {
+    pub struct PulseAudioDevice {
+        dev_str: String,
+    }
 
-    pub fn from_name(name: String) -> Result<Self, Error> {
-        let devices = PulseAudio::get_device_identifiers()?;
+    impl DeviceTrait for PulseAudioDevice {
 
-        for (id, names) in devices {
-            if name == names {
-                return Ok(PulseAudioDevice {
-                    dev_str: id,
-                });
+        // Name is device description (e.g. "Dummy Output")
+        fn from_name(name: String) -> Result<Self, Error> {
+            let devices = pulseaudio::get_device_identifiers()?;
+
+            for (id, names) in devices {
+                if name == names {
+                    return Ok(PulseAudioDevice {
+                        dev_str: id,
+                    });
+                }
             }
+            
+            Err(Error::DeviceNotFound)
+
         }
-        
-        Err(Error::DeviceNotFound)
 
-    }
+        // UID is device name (e.g. "auto_null")
+        fn from_uid(id: String) -> Result<Self, Error> {
+            let devices = pulseaudio::get_device_identifiers()?;
 
-    pub fn from_id(id: String) -> Result<Self, Error> {
-        let devices = PulseAudio::get_device_identifiers()?;
-
-        for (dev_str, _name) in devices {
-            if id == dev_str {
-                return Ok(PulseAudioDevice {
-                    dev_str,
-                });
+            for (dev_str, _name) in devices {
+                if id == dev_str {
+                    return Ok(PulseAudioDevice {
+                        dev_str,
+                    });
+                }
             }
+            
+            Err(Error::DeviceNotFound)
         }
-        
-        Err(Error::DeviceNotFound)
-    }
-
-    pub fn get_name(&self) -> Result<String, Error> {
-        PulseAudio::get_device_name(self.dev_str.clone())
-    }
-
-    pub fn get_device_str(&self) -> String {
-        self.dev_str.clone()
-    }
 
 
-    pub fn get_vol(&self) -> Result<f32, Error> {
-        let mut vol = 0.0;
-        let volume: Arc<Mutex<f32>> = Arc::new(Mutex::new(vol));
-        let clone = Arc::clone(&volume);
-        let dev_str = self.dev_str.clone();
-        let (mut mainloop, context) = PulseAudio::acquire_mainloop_and_context();
+        fn get_name(&self) -> Result<String, Error> {
+            pulseaudio::get_device_name(self.dev_str.clone())
+        }
 
-        let changed = Arc::new(Mutex::new(false));
-        let changed_clone = changed.clone();
 
-        let error = Arc::new(Mutex::new(None));
-        let err_clone = error.clone();
+        fn get_vol(&self) -> Result<f32, Error> {
+            let mut vol = 0.0;
+            let volume: Arc<Mutex<f32>> = Arc::new(Mutex::new(vol));
+            let clone = Arc::clone(&volume);
+            let dev_str = self.dev_str.clone();
+            let (mut mainloop, context) = pulseaudio::acquire_mainloop_and_context();
 
-        let op = context.introspect().get_sink_info_list( move |info | {
-                match info {
-                    libpulse_binding::callbacks::ListResult::Item(device) => {
-                        if let Some(name) = &device.name && name.to_string() == dev_str{
-                            if device.mute {
-                                *clone.lock().unwrap() = 0.0;
-                            } else {
-                                let mut vol_str = device.volume.avg().print().trim().to_string();
-                                vol_str.remove(vol_str.len() - 1);
-                                match vol_str.parse::<u8>() {
-                                    Ok(vol) => {
-                                        *clone.lock().unwrap() = vol as f32 / 100.0;
-                                    },
-                                    Err(err) => {
-                                        err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("Failed to parse volume string {}", err))); 
-                                        debug_eprintln(&format!("Failed to parse volume string {}", err));
+            let changed = Arc::new(Mutex::new(false));
+            let changed_clone = changed.clone();
+
+            let error = Arc::new(Mutex::new(None));
+            let err_clone = error.clone();
+
+            let op = context.introspect().get_sink_info_list( move |info | {
+                    match info {
+                        libpulse_binding::callbacks::ListResult::Item(device) => {
+                            if let Some(name) = &device.name && name.to_string() == dev_str{
+                                if device.mute {
+                                    *clone.lock().unwrap() = 0.0;
+                                } else {
+                                    let mut vol_str = device.volume.avg().print().trim().to_string();
+                                    vol_str.remove(vol_str.len() - 1);
+                                    match vol_str.parse::<u8>() {
+                                        Ok(vol) => {
+                                            *clone.lock().unwrap() = vol as f32 / 100.0;
+                                        },
+                                        Err(err) => {
+                                            err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("Failed to parse volume string {}", err))); 
+                                            debug_eprintln(&format!("Failed to parse volume string {}", err));
+                                        }
                                     }
                                 }
+                                *changed_clone.lock().unwrap() = true;
                             }
-                            *changed_clone.lock().unwrap() = true;
-                        }
-                    },
-                    libpulse_binding::callbacks::ListResult::End => {
-                        debug_println("Devices finished")
-                    },
-                    libpulse_binding::callbacks::ListResult::Error => {
-                        err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
-                        debug_eprintln("error gathering device information");
-                    },
-                }
-            });
-        
-        while op.get_state() == libpulse_binding::operation::State::Running {
-            mainloop.iterate(false);
-        }
-
-        mainloop.quit(libpulse_binding::def::Retval(0));
-
-        vol = *volume.lock().unwrap();
-        if let Some(error) = error.lock().unwrap().take() {
-            Err(error)
-        } else if *changed.lock().unwrap() {
-            Ok(vol)
-        } else {
-            Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
-        }
-    }
-
-    pub fn set_vol(&self, value: f32) -> Result<(), Error> {
-        let mut success = None;
-        let vol_channels = Arc::new(Mutex::new(None));
-        let clone = Arc::clone(&vol_channels);
-        let dev_str = self.dev_str.clone();
-
-        let changed = Arc::new(Mutex::new(false));
-        let changed_clone = changed.clone();
-
-        let error = Arc::new(Mutex::new(None));
-        let err_clone = error.clone();
-
-        let (mut mainloop, context) = PulseAudio::acquire_mainloop_and_context();
-        let op = context.introspect().get_sink_info_list( move |info | {
-                match info {
-                    libpulse_binding::callbacks::ListResult::Item(device) => {
-                        if let Some(name) = &device.name && name.to_string() == dev_str {
-                            use libpulse_binding::volume::{Volume};
-                            use libpulse_sys::volume::PA_VOLUME_NORM;
-                            let vol = Volume((value * PA_VOLUME_NORM as f32) as u32);
-                            let mut channel_vols = device.volume;
-                            channel_vols.set(device.sample_spec.channels, vol.into());
-                            clone.lock().unwrap().replace((device.index, channel_vols));
-                            *changed_clone.lock().unwrap() = true;
-                        }
-                    },
-                    libpulse_binding::callbacks::ListResult::End => {
-                        debug_println("channel volume aquired");
-                    },
-                    libpulse_binding::callbacks::ListResult::Error => {
-                        err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
-                        debug_eprintln("error gathering device information");    
-                    },
-                }
-            });
-
-        
-        while op.get_state() == libpulse_binding::operation::State::Running {
-            mainloop.iterate(false);
-        }
-
-        if let Some((index, volume)) = vol_channels.lock().unwrap().take() {
-            let vol_runner;
-            if value == 0.0 {
-                vol_runner = context.introspect().set_sink_mute_by_index(index, true, None);
-            } else {
-                vol_runner = context.introspect().set_sink_volume_by_index(index, &volume, None);
-            }             
-            while vol_runner.get_state() == libpulse_binding::operation::State::Running {
+                        },
+                        libpulse_binding::callbacks::ListResult::End => {
+                            debug_println("Devices finished")
+                        },
+                        libpulse_binding::callbacks::ListResult::Error => {
+                            err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
+                            debug_eprintln("error gathering device information");
+                        },
+                    }
+                });
+            
+            while op.get_state() == libpulse_binding::operation::State::Running {
                 mainloop.iterate(false);
-                success = Some(true);
             }
-        } else {
-            success = Some(false);
+
+            mainloop.quit(libpulse_binding::def::Retval(0));
+
+            vol = *volume.lock().unwrap();
+            if let Some(error) = error.lock().unwrap().take() {
+                Err(error)
+            } else if *changed.lock().unwrap() {
+                Ok(vol)
+            } else {
+                Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
+            }
         }
 
-        mainloop.quit(libpulse_binding::def::Retval(0));
+        fn set_vol(&self, value: f32) -> Result<(), Error> {
+            let mut success = None;
+            let vol_channels = Arc::new(Mutex::new(None));
+            let clone = Arc::clone(&vol_channels);
+            let dev_str = self.dev_str.clone();
 
-        if let Some(error) = error.lock().unwrap().take() {
-            Err(error)
-        } else if !*changed.lock().unwrap() {
-            Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
-        } else {
-            match success {
-                Some(val) => {
-                    if val {
-                        Ok(())
-                    } else {
+            let changed = Arc::new(Mutex::new(false));
+            let changed_clone = changed.clone();
+
+            let error = Arc::new(Mutex::new(None));
+            let err_clone = error.clone();
+
+            let (mut mainloop, context) = pulseaudio::acquire_mainloop_and_context();
+            let op = context.introspect().get_sink_info_list( move |info | {
+                    match info {
+                        libpulse_binding::callbacks::ListResult::Item(device) => {
+                            if let Some(name) = &device.name && name.to_string() == dev_str {
+                                use libpulse_binding::volume::{Volume};
+                                use libpulse_sys::volume::PA_VOLUME_NORM;
+                                let vol = Volume((value * PA_VOLUME_NORM as f32) as u32);
+                                let mut channel_vols = device.volume;
+                                channel_vols.set(device.sample_spec.channels, vol.into());
+                                clone.lock().unwrap().replace((device.index, channel_vols));
+                                *changed_clone.lock().unwrap() = true;
+                            }
+                        },
+                        libpulse_binding::callbacks::ListResult::End => {
+                            debug_println("channel volume aquired");
+                        },
+                        libpulse_binding::callbacks::ListResult::Error => {
+                            err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
+                            debug_eprintln("error gathering device information");    
+                        },
+                    }
+                });
+
+            
+            while op.get_state() == libpulse_binding::operation::State::Running {
+                mainloop.iterate(false);
+            }
+
+            if let Some((index, volume)) = vol_channels.lock().unwrap().take() {
+                let vol_runner;
+                if value == 0.0 {
+                    vol_runner = context.introspect().set_sink_mute_by_index(index, true, None);
+                } else {
+                    vol_runner = context.introspect().set_sink_volume_by_index(index, &volume, None);
+                }             
+                while vol_runner.get_state() == libpulse_binding::operation::State::Running {
+                    mainloop.iterate(false);
+                    success = Some(true);
+                }
+            } else {
+                success = Some(false);
+            }
+
+            mainloop.quit(libpulse_binding::def::Retval(0));
+
+            if let Some(error) = error.lock().unwrap().take() {
+                Err(error)
+            } else if !*changed.lock().unwrap() {
+                Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
+            } else {
+                match success {
+                    Some(val) => {
+                        if val {
+                            Ok(())
+                        } else {
+                            Err(Error::VolumeCaptureFailed(format!("Failed to adjust device volume")))
+                        }
+                    }
+                    None => {
                         Err(Error::VolumeCaptureFailed(format!("Failed to adjust device volume")))
                     }
                 }
-                None => {
-                    Err(Error::VolumeCaptureFailed(format!("Failed to adjust device volume")))
-                }
             }
         }
-    }
 
-    pub fn get_mute(&self) -> Result<bool, Error> {
-        let mute;
-        let mute_status = Arc::new(Mutex::new(0));
-        let clone = Arc::clone(&mute_status);
-        let dev_str = self.dev_str.clone();
+        fn get_mute(&self) -> Result<bool, Error> {
+            let mute;
+            let mute_status = Arc::new(Mutex::new(0));
+            let clone = Arc::clone(&mute_status);
+            let dev_str = self.dev_str.clone();
 
-        let (mut mainloop, context) = PulseAudio::acquire_mainloop_and_context();
+            let (mut mainloop, context) = pulseaudio::acquire_mainloop_and_context();
 
-        let changed = Arc::new(Mutex::new(false));
-        let changed_clone = changed.clone();
+            let changed = Arc::new(Mutex::new(false));
+            let changed_clone = changed.clone();
 
-        let error = Arc::new(Mutex::new(None));
-        let err_clone = error.clone();
+            let error = Arc::new(Mutex::new(None));
+            let err_clone = error.clone();
 
-        let op = context.introspect().get_sink_info_list( move |info | {
-                match info {
-                    libpulse_binding::callbacks::ListResult::Item(device) => {
-                        
-                        if let Some(name) = &device.name && name.to_string() == dev_str {
-                            if device.mute {
-                                *clone.lock().unwrap() = 1;
+            let op = context.introspect().get_sink_info_list( move |info | {
+                    match info {
+                        libpulse_binding::callbacks::ListResult::Item(device) => {
+                            
+                            if let Some(name) = &device.name && name.to_string() == dev_str {
+                                if device.mute {
+                                    *clone.lock().unwrap() = 1;
+                                }
+                                *changed_clone.lock().unwrap() = true;
                             }
-                            *changed_clone.lock().unwrap() = true;
-                        }
-                    },
-                    libpulse_binding::callbacks::ListResult::End => {
-                        debug_println("Devices finished")
-                    },
-                    libpulse_binding::callbacks::ListResult::Error => {
-                        err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
-                        debug_eprintln("error gathering device information");
-                    },
-                }
-            });
-        
-        while op.get_state() == libpulse_binding::operation::State::Running {
-            mainloop.iterate(false);
-        }
+                        },
+                        libpulse_binding::callbacks::ListResult::End => {
+                            debug_println("Devices finished")
+                        },
+                        libpulse_binding::callbacks::ListResult::Error => {
+                            err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
+                            debug_eprintln("error gathering device information");
+                        },
+                    }
+                });
+            
+            while op.get_state() == libpulse_binding::operation::State::Running {
+                mainloop.iterate(false);
+            }
 
-        mainloop.quit(libpulse_binding::def::Retval(0));
+            mainloop.quit(libpulse_binding::def::Retval(0));
 
-        mute = *mute_status.lock().unwrap();
-        if let Some(error) = error.lock().unwrap().take() {
-            Err(error)
-        } else if !*changed.lock().unwrap() {
-            Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
-        } else {
-            match mute {
-                1 => {
-                    Ok(true)
-                }
-                _ => {
-                    Ok(false)
+            mute = *mute_status.lock().unwrap();
+            if let Some(error) = error.lock().unwrap().take() {
+                Err(error)
+            } else if !*changed.lock().unwrap() {
+                Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
+            } else {
+                match mute {
+                    1 => {
+                        Ok(true)
+                    }
+                    _ => {
+                        Ok(false)
+                    }
                 }
             }
         }
+
+        fn set_mute(&self, mute: bool) -> Result<(), Error> {
+            let mut status = false;
+            let dev_index = Arc::new(Mutex::new(None));
+            let dev_str = self.dev_str.clone();
+            let clone = Arc::clone(&dev_index);
+
+            let (mut mainloop, context) = pulseaudio::acquire_mainloop_and_context();
+
+            let changed = Arc::new(Mutex::new(false));
+            let changed_clone = changed.clone();
+
+            let error = Arc::new(Mutex::new(None));
+            let err_clone = error.clone();
+
+            let op = context.introspect().get_sink_info_list( move |info | {
+                    match info {
+                        libpulse_binding::callbacks::ListResult::Item(device) => {
+                            if let Some(name) = &device.name && name.to_string() == dev_str{
+                                clone.lock().unwrap().replace(device.index);
+                                *changed_clone.lock().unwrap() = true;
+                            }
+                        },
+                        libpulse_binding::callbacks::ListResult::End => {
+                            debug_println("channel volume aquired");
+                        },
+                        libpulse_binding::callbacks::ListResult::Error => {
+                            err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
+                            debug_eprintln("error gathering device information");    
+                        },
+                    }
+                });
+
+            
+            while op.get_state() == libpulse_binding::operation::State::Running {
+                mainloop.iterate(false);
+            }
+
+
+            if let Some(index) = dev_index.lock().unwrap().take() {
+                let mute_runner;
+                mute_runner = context.introspect().set_sink_mute_by_index(index, mute, None);        
+                while mute_runner.get_state() == libpulse_binding::operation::State::Running {
+                    mainloop.iterate(false);
+                    status = true;
+                }
+            } else {
+                status = false;
+            }
+            mainloop.quit(libpulse_binding::def::Retval(0));
+            if let Some(error) = error.lock().unwrap().take() {
+                Err(error)
+            } else if !*changed.lock().unwrap() {
+                Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
+            } else {
+                match status {
+                    true => {
+                        Ok(())
+                    }
+                    false => {
+                        Err(Error::VolumeCaptureFailed(format!("Failed to adjust device volume")))
+                    }
+                }
+            }
+        } 
     }
 
-    pub fn set_mute(&self, mute: bool) -> Result<(), Error> {
-        let mut status = false;
-        let dev_index = Arc::new(Mutex::new(None));
-        let dev_str = self.dev_str.clone();
-        let clone = Arc::clone(&dev_index);
-
-        let (mut mainloop, context) = PulseAudio::acquire_mainloop_and_context();
-
-        let changed = Arc::new(Mutex::new(false));
-        let changed_clone = changed.clone();
-
-        let error = Arc::new(Mutex::new(None));
-        let err_clone = error.clone();
-
-        let op = context.introspect().get_sink_info_list( move |info | {
-                match info {
-                    libpulse_binding::callbacks::ListResult::Item(device) => {
-                        if let Some(name) = &device.name && name.to_string() == dev_str{
-                            clone.lock().unwrap().replace(device.index);
-                            *changed_clone.lock().unwrap() = true;
-                        }
-                    },
-                    libpulse_binding::callbacks::ListResult::End => {
-                        debug_println("channel volume aquired");
-                    },
-                    libpulse_binding::callbacks::ListResult::Error => {
-                        err_clone.lock().unwrap().replace(Error::VolumeCaptureFailed(format!("ListResult Access Error"))); 
-                        debug_eprintln("error gathering device information");    
-                    },
-                }
-            });
-
-        
-        while op.get_state() == libpulse_binding::operation::State::Running {
-            mainloop.iterate(false);
+    impl PulseAudioDevice {
+        pub fn get_device_str(&self) -> String {
+            self.dev_str.clone()
         }
-
-
-        if let Some(index) = dev_index.lock().unwrap().take() {
-            let mute_runner;
-            mute_runner = context.introspect().set_sink_mute_by_index(index, mute, None);        
-            while mute_runner.get_state() == libpulse_binding::operation::State::Running {
-                mainloop.iterate(false);
-                status = true;
-            }
-        } else {
-            status = false;
-        }
-        mainloop.quit(libpulse_binding::def::Retval(0));
-        if let Some(error) = error.lock().unwrap().take() {
-            Err(error)
-        } else if !*changed.lock().unwrap() {
-            Err(Error::VolumeCaptureFailed(format!("Failed to detect device")))
-        } else {
-            match status {
-                true => {
-                    Ok(())
-                }
-                false => {
-                    Err(Error::VolumeCaptureFailed(format!("Failed to adjust device volume")))
-                }
-            }
-        }
-    } 
+    }
+    
 }
+
+#[cfg(not(target_os="linux"))]
+// #[cfg(target_os="linux")]
+
+mod device {
+
+    use std::sync::{Arc, Mutex};
+    use crate::{debug_eprintln, debug_println, device::DeviceTrait, error::Error, pulseaudio};
+
+    pub struct PulseAudioDevice {
+        dev_str: String,
+    }
+
+    impl DeviceTrait for PulseAudioDevice {}
+
+    impl PulseAudioDevice {
+        pub fn get_device_str(&self) -> String {
+            String::from("CPVC: Platform Unsupported")
+        }
+    }
+    
+}
+
+pub(crate) use device::*; 

--- a/src/pulseaudio/mod.rs
+++ b/src/pulseaudio/mod.rs
@@ -1,45 +1,18 @@
-use libpulse_binding::{
-    context::{Context, introspect::SinkInfo}, 
-    callbacks::ListResult,
-    mainloop::standard::Mainloop,
-    proplist::Proplist
-};
-use std::sync::{Arc, Mutex};
-use crate::{VolumeControl, debug_eprintln, debug_println, error::Error, pulseaudio::device::PulseAudioDevice};
-
 pub mod device;
 
-
+// #[cfg(not(target_os="linux"))]
+#[cfg(target_os="linux")]
 // Currently no functionality to detect jacks, only output audio cards
-pub struct PulseAudio {}
+pub mod pulseaudio {
+    use libpulse_binding::{
+        context::{Context, introspect::SinkInfo}, 
+        callbacks::ListResult,
+        mainloop::standard::Mainloop,
+        proplist::Proplist
+    };
+    use std::sync::{Arc, Mutex};
+    use crate::{VolumeControl, debug_eprintln, debug_println, device::DeviceTrait, error::Error, pulseaudio::device::PulseAudioDevice};
 
-impl VolumeControl for PulseAudio {
-    fn get_sound_devices() -> Result<Vec<String>, Error> {
-        Ok(PulseAudio::get_device_identifiers()?.into_iter().map(|(_id, name)| name).collect())
-    }
-
-    fn get_vol() -> Result<f32, Error> {
-        let default_dev = PulseAudio::get_default_output_dev()?;
-        default_dev.get_vol()
-    }
-
-    fn set_vol(value: f32) -> Result<(), Error> {
-        let default_dev = PulseAudio::get_default_output_dev()?;
-        default_dev.set_vol(value)
-    }
-
-    fn get_mute() -> Result<bool, Error> {
-        let default_dev = PulseAudio::get_default_output_dev()?;
-        default_dev.get_mute()
-    }
-
-    fn set_mute(state: bool) -> Result<(), Error> {
-        let default_dev = PulseAudio::get_default_output_dev()?;
-        default_dev.set_mute(state)
-    }
-}
-
-impl PulseAudio {
     pub fn get_device_identifiers() -> Result<Vec<(String, String)>, Error> {
         let mut devices: Vec<(String, String)> = Vec::new();
         
@@ -103,7 +76,7 @@ impl PulseAudio {
         Ok(devices)
     }
 
-    pub fn acquire_mainloop_and_context() -> (Mainloop, Context) {
+    pub(super) fn acquire_mainloop_and_context() -> (Mainloop, Context) {
         let mut mainloop = Mainloop::new().expect("Failed to create mainloop");
         let proplist = Proplist::new().unwrap();
         let mut context = Context::new_with_proplist(&mainloop, "CPVC", &proplist)
@@ -132,7 +105,7 @@ impl PulseAudio {
         let default_dev = Arc::new(Mutex::new(String::new()));
         let clone = Arc::clone(&default_dev);
 
-        let (mut mainloop, context) = PulseAudio::acquire_mainloop_and_context();
+        let (mut mainloop, context) = acquire_mainloop_and_context();
         let op = context.introspect().get_sink_info_list( move |info | {
                 match info {
                     libpulse_binding::callbacks::ListResult::Item(device) => {
@@ -160,7 +133,7 @@ impl PulseAudio {
     }
 
     pub fn get_device_id(name: String) -> Result<String, Error> {
-        let devices = PulseAudio::get_device_identifiers()?;
+        let devices = get_device_identifiers()?;
         for (dev_str, names) in devices {
             if names == name {
                 return Ok(dev_str);
@@ -170,7 +143,7 @@ impl PulseAudio {
     }
 
     pub fn get_device_name(id: String) -> Result<String, Error> {
-        let devices = PulseAudio::get_device_identifiers()?;
+        let devices = get_device_identifiers()?;
         for (dev_str, name) in devices {
             if id == dev_str {
                 return Ok(name);
@@ -178,4 +151,78 @@ impl PulseAudio {
         }
         Err(Error::DeviceNotFound)
     }
+
+
+    // Volume Controls
+    pub fn get_sound_devices() -> Result<Vec<String>, Error> {
+        Ok(get_device_identifiers()?.into_iter().map(|(_id, name)| name).collect())
+    }
+
+    pub fn get_vol() -> Result<f32, Error> {
+        let default_dev = get_default_output_dev()?;
+        default_dev.get_vol()
+    }
+
+    pub fn set_vol(value: f32) -> Result<(), Error> {
+        let default_dev = get_default_output_dev()?;
+        default_dev.set_vol(value)
+    }
+
+    pub fn get_mute() -> Result<bool, Error> {
+        let default_dev = get_default_output_dev()?;
+        default_dev.get_mute()
+    }
+
+    pub fn set_mute(state: bool) -> Result<(), Error> {
+        let default_dev = get_default_output_dev()?;
+        default_dev.set_mute(state)
+    }
+    
 }
+
+#[cfg(not(target_os="linux"))]
+// #[cfg(target_os="linux")]
+// Currently no functionality to detect jacks, only output audio cards
+pub mod pulseaudio {
+    pub fn get_device_identifiers() -> Result<Vec<(String, String)>, Error> {
+       Err(Error::PlatformUnsupported)
+    }
+
+    // Default output device does not work when Pro Audio is selected as a playback device
+    pub fn get_default_output_dev() -> Result<PulseAudioDevice, Error> {
+       Err(Error::PlatformUnsupported)
+    }
+
+    pub fn get_device_id(name: String) -> Result<String, Error> {
+        Err(Error::PlatformUnsupported)
+    }
+
+    pub fn get_device_name(id: String) -> Result<String, Error> {
+        Err(Error::PlatformUnsupported)
+    }
+
+
+    // Volume Controls
+    pub fn get_sound_devices() -> Result<Vec<String>, Error> {
+        Err(Error::PlatformUnsupported)
+    }
+
+    pub fn get_vol() -> Result<f32, Error> {
+        Err(Error::PlatformUnsupported)
+    }
+
+    pub fn set_vol(value: f32) -> Result<(), Error> {
+        Err(Error::PlatformUnsupported)
+    }
+
+    pub fn get_mute() -> Result<bool, Error> {
+        Err(Error::PlatformUnsupported)
+    }
+
+    pub fn set_mute(state: bool) -> Result<(), Error> {
+        Err(Error::PlatformUnsupported)
+    }
+    
+}
+
+pub(crate) use pulseaudio::*;

--- a/src/pulseaudio/mod.rs
+++ b/src/pulseaudio/mod.rs
@@ -184,6 +184,8 @@ pub mod pulseaudio {
 // #[cfg(target_os="linux")]
 // Currently no functionality to detect jacks, only output audio cards
 pub mod pulseaudio {
+    use crate::{error::Error, pulseaudio::device::PulseAudioDevice};
+
     pub fn get_device_identifiers() -> Result<Vec<(String, String)>, Error> {
        Err(Error::PlatformUnsupported)
     }


### PR DESCRIPTION
## Description
This pull request creates a new `UnifiedDevice` which is exposed as a `Device` when used in the crate, automatically selecting the different audio APIs based on OS. This allows for one umbrella `Device` struct that can be easily used instead of importing all the API specific structs.

## Changes
* Shell APIs have been created for all three audio APIs (CoreAudio, PulseAudio, WASAPI), allowing them to be imported even when not on the target platform. Using methods from an API that isn't compatible with the target platform will return `Error::PlatformUnsupported`.
* All Device APIs now implement the `DeviceTrait` trait, with basic common methods between all APIs
* UnifiedDevice<T> struct stores a Device supporting `DeviceTrait`. It is exposed as `Device` with the audio API being automatically selected based on the current OS.

